### PR TITLE
Make ergo sync elements to be `Send` and `Sync`

### DIFF
--- a/ergo-chain-sync/src/cache/chain_cache.rs
+++ b/ergo-chain-sync/src/cache/chain_cache.rs
@@ -5,7 +5,7 @@ use ergo_lib::ergo_chain_types::{BlockId, Digest32};
 
 use crate::model::{Block, BlockRecord};
 
-#[async_trait(?Send)]
+#[async_trait]
 pub trait ChainCache {
     async fn append_block(&mut self, block: Block);
     async fn exists(&mut self, block_id: BlockId) -> bool;
@@ -33,7 +33,7 @@ impl Default for InMemoryCache {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl ChainCache for InMemoryCache {
     async fn append_block(&mut self, block: Block) {
         let id = block.id;

--- a/ergo-chain-sync/src/cache/rocksdb.rs
+++ b/ergo-chain-sync/src/cache/rocksdb.rs
@@ -47,7 +47,7 @@ impl ChainCacheRocksDB {
 
 /// The Rocksdb bindings are not async, so we must wrap any uses of the library in
 /// `async_std::task::spawn_blocking`.
-#[async_trait(?Send)]
+#[async_trait]
 impl ChainCache for ChainCacheRocksDB {
     async fn append_block(&mut self, block: Block) {
         let db = self.db.clone();

--- a/ergo-chain-sync/src/client/node.rs
+++ b/ergo-chain-sync/src/client/node.rs
@@ -24,7 +24,7 @@ pub enum Error {
     NoBlock,
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 pub trait ErgoNetwork {
     async fn get_block_at(&self, height: u32) -> Result<FullBlock, Error>;
     async fn fetch_mempool(&self, offset: usize, limit: usize) -> Result<Vec<Transaction>, Error>;
@@ -43,7 +43,7 @@ impl ErgoNodeHttpClient {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl ErgoNetwork for ErgoNodeHttpClient {
     async fn get_block_at(&self, height: u32) -> Result<FullBlock, Error> {
         let blocks = self
@@ -135,8 +135,11 @@ impl<R> ErgoNetworkTracing<R> {
     }
 }
 
-#[async_trait(?Send)]
-impl<R> ErgoNetwork for ErgoNetworkTracing<R> where R: ErgoNetwork {
+#[async_trait]
+impl<R> ErgoNetwork for ErgoNetworkTracing<R>
+where
+    R: ErgoNetwork + Send + Sync,
+{
     async fn get_block_at(&self, height: u32) -> Result<FullBlock, Error> {
         trace!(target: "ergo_network", "get_block_at(height: {})", height);
         self.inner.get_block_at(height).await

--- a/spectrum-offchain-lm/src/data/pool.rs
+++ b/spectrum-offchain-lm/src/data/pool.rs
@@ -314,7 +314,7 @@ impl Pool {
                             / (self.conf.epoch_num as u128),
                     )
                     .saturating_sub(1);
-                ((alloc_rem * bundle.vlq.amount as u128 * epochs_burned as u128 / actual_tmp as u128) as u64)
+                (alloc_rem * bundle.vlq.amount as u128 * epochs_burned as u128 / actual_tmp as u128) as u64
             } else {
                 0
             };


### PR DESCRIPTION
The following changes were made so that `ergo_chain_sync` code can be used in the spectrum data bridge (which will be spawned in a separate async task, and so elements need to move across threads):
- Replaced `Rc<RefCell..>` elements with `Arc<Mutex..>` in `ChainSync`
- Replace `#[async_trait(?Send)]` with `#[async_trait]` for some traits.
